### PR TITLE
Add Prepared to HV list

### DIFF
--- a/Specialization/Havoc.lua
+++ b/Specialization/Havoc.lua
@@ -63,6 +63,7 @@ local HV = {
 	ThrowGlaive     = 185123,
 	VengefulRetreat = 198793,
 	FelMastery      = 192939,
+	Prepared	= 203650,
 };
 
 local A = {


### PR DESCRIPTION
Fixes chat spam "Spell Key Prepared not found!" with Havoc.