### PR TITLE
Fix spell not found bug, improve CD utilization

### DIFF
--- a/Specialization/Vengeance.lua
+++ b/Specialization/Vengeance.lua
@@ -38,6 +38,7 @@ function DemonHunter:Vengeance()
 	local currentSpell = fd.currentSpell;
 	local pain = UnitPower('player', Enum.PowerType.Pain);
 	local soulFragments = buff[VG.SoulFragments].count;
+	local SigilOfFlame = talents[VG.ConcentratedSigils] and VG.SigilOfFlame2 or VG.SigilOfFlame;
 
 	MaxDps:GlowEssences();
 	MaxDps:GlowCooldown(VG.Metamorphosis, cooldown[VG.Metamorphosis].ready);
@@ -80,6 +81,16 @@ function DemonHunter:Vengeance()
 	if pain <= 90 and cooldown[VG.ImmolationAura].ready then
 		return VG.ImmolationAura;
 	end
+	
+	-- fel_devastation;
+	if talents[VG.FelDevastation] and cooldown[VG.FelDevastation].ready and currentSpell ~= VG.FelDevastation then
+		return VG.FelDevastation;
+	end
+
+	-- sigil_of_flame;
+	if cooldown[SigilOfFlame].ready then
+		return SigilOfFlame;
+	end
 
 	-- felblade,if=pain<=70;
 	if talents[VG.Felblade] and cooldown[VG.Felblade].ready and pain <= 70 then
@@ -89,17 +100,6 @@ function DemonHunter:Vengeance()
 	-- fracture,if=soul_fragments<=3;
 	if talents[VG.Fracture] and soulFragments <= 3 and cooldown[VG.Fracture].ready then
 		return VG.Fracture;
-	end
-
-	-- fel_devastation;
-	if talents[VG.FelDevastation] and cooldown[VG.FelDevastation].ready and currentSpell ~= VG.FelDevastation then
-		return VG.FelDevastation;
-	end
-
-	-- sigil_of_flame;
-	local SigilOfFlame = talents[VG.ConcentratedSigils] and VG.SigilOfFlame2 or VG.SigilOfFlame;
-	if cooldown[SigilOfFlame].ready then
-		return SigilOfFlame;
 	end
 
 	-- shear;
@@ -121,10 +121,11 @@ function DemonHunter:VengeanceBrand()
 	local debuff = fd.debuff;
 	local talents = fd.talents;
 	local currentSpell = fd.currentSpell;
+	local SigilOfFlame = talents[VG.ConcentratedSigils] and VG.SigilOfFlame2 or VG.SigilOfFlame;
 
 	-- sigil_of_flame,if=cooldown.fiery_brand.remains<2;
-	if cooldown[VG.FieryBrand].remains < 2 and cooldown[VG.SigilOfFlame].ready then
-		return VG.SigilOfFlame;
+	if cooldown[VG.FieryBrand].remains < 2 and cooldown[SigilOfFlame].ready then
+		return SigilOfFlame;
 	end
 
 	---- infernal_stike,if=cooldown.fiery_brand.remains=0;
@@ -149,7 +150,7 @@ function DemonHunter:VengeanceBrand()
 	end
 
 	-- sigil_of_flame,if=dot.fiery_brand.ticking;
-	if debuff[VG.FieryBrand].up and cooldown[VG.SigilOfFlame].ready then
-		return VG.SigilOfFlame;
+	if debuff[VG.FieryBrand].up and cooldown[SigilOfFlame].ready then
+		return SigilOfFlame;
 	end
 end


### PR DESCRIPTION
This fixes spell not found bug when using Concentrated Sigils and Charred Flesh at the same time, and improves short CD utilization in the normal rotation.